### PR TITLE
Adds `state_header_path` argument

### DIFF
--- a/src/wasm_upload.rs
+++ b/src/wasm_upload.rs
@@ -1,4 +1,3 @@
-use candid::encode_one;
 use clap::Args;
 use ic_agent::{ic_types::Principal, Agent, AgentError};
 use std::{fs, time::Duration};
@@ -6,8 +5,11 @@ use std::{fs, time::Duration};
 #[derive(Args)]
 pub struct WasmUpload {
     /// Path to the wasm you want to upload
-    #[clap(long, short)]
     path: String,
+
+    /// Path to the state header file. If not set, the file path will be considered to be the same
+    /// as the `path` parameter but with `.header` extension.
+    state_header_path: Option<String>,
 
     /// method name to call on the canister
     #[clap(long, short, default_value = "set_token_bytecode")]
@@ -19,27 +21,45 @@ pub struct WasmUpload {
 }
 
 impl WasmUpload {
-    async fn upload(&self, agent: &Agent, wasm: &Vec<u8>) -> Result<Vec<u8>, AgentError> {
+    async fn upload(
+        &self,
+        agent: &Agent,
+        wasm: &Vec<u8>,
+        state_header: &Vec<u8>,
+    ) -> Result<Vec<u8>, AgentError> {
         println!("Uploading wasm...");
 
         let waiter = garcon::Delay::builder()
             .timeout(Duration::from_secs(60 * 5))
             .build();
+        let args = candid::encode_args((wasm, state_header)).unwrap();
 
         agent
             .update(&self.canister_id, &self.method_name)
-            .with_arg(&encode_one(&wasm).unwrap())
+            .with_arg(args)
             .call_and_wait(waiter)
             .await
     }
 
     pub async fn run(&self, agent: &Agent) {
         let wasm = fs::read(&self.path).unwrap();
+        let state_header = self.read_state_header();
 
-        self.upload(agent, &wasm)
+        self.upload(agent, &wasm, &state_header)
             .await
             .expect("failed to upload wasm");
 
         println!("Done!");
+    }
+
+    fn read_state_header(&self) -> Vec<u8> {
+        fs::read(&self.state_header_path()).unwrap()
+    }
+
+    fn state_header_path(&self) -> std::path::PathBuf {
+        self.state_header_path
+            .as_ref()
+            .map(|v| std::path::Path::new(v).to_path_buf())
+            .unwrap_or_else(|| std::path::Path::new(&self.path).with_extension(".header"))
     }
 }


### PR DESCRIPTION
The factory method to uppload the bytecode is changed to also accespt
the state header for upgrade checks. This PR adds the logic to send this
state header to the factory along with the wasm.

I also changed the `path` parameter to be a positional parameter instead
of non-optional named parameter (just because having non-optional named
parameters is not cool).